### PR TITLE
965 - Extra fishing features in track

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,4 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
 * [#887](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/887): Adds vessel search and vessel information endpoints, which gets that information from an elastic search cluster. You can configure the elastic search connection through the `elasticsearch` settings in the [config.js](src/config.js) file.
+* [#965](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/965): Adds extra features and properties to the GeoJSON object returned in the tracks endpoints. This allows the client to require fishing geometries and per-coordinate data such as speed and course by sending a `features` parameter to the API.

--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -161,6 +161,19 @@ paths:
             Id of the vessel to get the tracks for
           required: true
           type: string
+        - name: features
+          in: query
+          description: |
+            Comma-separated list of additional features to include in the
+            tracks, such as points classified as fishing, per-point speed and
+            courses, etc.
+          type: array
+          items:
+            type: string
+            enum:
+              - fishing
+              - speed
+              - course
       responses:
         '200':
           description: |
@@ -169,4 +182,3 @@ paths:
           $ref: '#/responses/Unauthorized'
         '400':
           $ref: '#/responses/BadRequest'
-

--- a/src/data/tracks.js
+++ b/src/data/tracks.js
@@ -1,36 +1,123 @@
+const constant = require('lodash/fp/constant');
+const filter = require('lodash/fp/filter');
+const flatMap = require('lodash/fp/flatMap');
+const flow = require('lodash/fp/flow');
+const identity = require('lodash/fp/identity');
+const isEmpty = require('lodash/fp/isEmpty');
+const map = require('lodash/fp/map');
+const reduce = require('lodash/fp/reduce');
+const reject = require('lodash/fp/reject');
+const zip = require('lodash/fp/zip');
+const keys = require('lodash/fp/keys');
 const sql = require('../services/google/sql');
+const log = require('../data/log');
+
+const additionalFeatureSettings = {
+  fishing: {
+    extraFields: 'scores',
+    updateCoordinateProperties: segment => identity,
+    buildExtraGeoJSONFeatures: segment => {
+      const coordinates = flow(
+        zip(segment.scores),
+        filter(([score, coordinate]) => score > 0.5),
+        map(([score, coordinate]) => coordinate),
+      )(segment.geojson.coordinates);
+
+      if (isEmpty(coordinates)) {
+        return {};
+      }
+
+      return {
+        type: "Feature",
+        properties: {
+          track: segment.id,
+          type: "fishing",
+        },
+        geometry: {
+          type: "MultiPoint",
+            coordinates,
+        },
+      };
+    },
+  },
+
+  course: {
+    extraFields: 'courses',
+    updateCoordinateProperties: segment => coordinateProperties => ({
+      courses: segment.courses,
+      ...coordinateProperties,
+    }),
+    buildExtraGeoJSONFeatures: constant([]),
+  },
+
+  speed: {
+    extraFields: 'speeds',
+    updateCoordinateProperties: segment => coordinateProperties => ({
+      speeds: segment.speeds,
+      ...coordinateProperties,
+    }),
+    buildExtraGeoJSONFeatures: constant([]),
+  },
+};
+
+const segmentToGeoJSONTrack = (segment, extraFeatures = []) => {
+  const geometry = segment.geojson;
+  if (geometry.coordinates.length > 1) {
+    geometry.type = 'LineString';
+  }
+
+  const reduceCoordinateProperties = (result, feature) => feature
+    .updateCoordinateProperties(segment)(result);
+
+  const coordinateProperties = reduce(reduceCoordinateProperties)({times: segment.times})(extraFeatures);
+
+  return {
+    type: "Feature",
+    properties: {
+      id: segment.id,
+      type: "track",
+      coordinateProperties,
+    },
+    geometry,
+  };
+};
+
+const queryResultsToGeoJSON = (segments, extraFeatures) => {
+  log.debug("Query results available, converting to GeoJSON");
+  const features = flow(
+    map(segment => ({
+      ...segment,
+      geojson: JSON.parse(segment.geojson),
+    })),
+    flatMap(segment => [
+      segmentToGeoJSONTrack(segment, extraFeatures),
+      ...map(feature => feature.buildExtraGeoJSONFeatures(segment))(extraFeatures),
+    ]),
+    reject(isEmpty),
+  )(segments);
+
+  return {
+    type: "FeatureCollection",
+    features,
+  };
+};
 
 module.exports = dataset => ({
-  forVessel(vesselId) {
+  forVessel(vesselId, additionalFeatures = []) {
+    log.debug(`Looking up track for vessel ${vesselId} including features ${additionalFeatures}`);
+    const extraFeatures = map(feature => additionalFeatureSettings[feature])(additionalFeatures);
+
     const query = sql
       .select(
-        "times",
-        sql.raw('ST_AsGeoJSON("seg_geography") as "geojson"')
+        'tracks.seg_id as id',
+        'times',
+        sql.raw('ST_AsGeoJSON("seg_geography") as "geojson"'),
+        ...extraFeatures.map(feature => feature.extraFields),
       )
       .from({tracks: dataset.tracksTable})
       .innerJoin({vessels: dataset.vesselsTable}, "tracks.seg_id", "vessels.seg_id")
       .where("vessels.vessel_id", vesselId);
 
-    return query.then((records) => {
-      const features = records.map((segment) => {
-        const geometry = JSON.parse(segment.geojson);
-        geometry.type = 'LineString';
-
-        return {
-          type: "Feature",
-          properties: {
-            coordinateProperties: {
-              times: segment.times,
-            },
-          },
-          geometry,
-        };
-      });
-
-      return {
-        type: "FeatureCollection",
-        features,
-      }
-    });
+    return query.then((segments) => queryResultsToGeoJSON(segments, extraFeatures));
   },
 });

--- a/src/data/vessels.js
+++ b/src/data/vessels.js
@@ -1,11 +1,12 @@
 const elasticsearch = require('../services/elasticsearch');
 
+// eslint-disable-next-line no-underscore-dangle
 const transformSearchResult = entry => entry._source;
 
 const calculateNextOffset = (query, results) => (
-  query.offset + query.limit <= results.hits.total ?
-    query.offset + query.limit :
-    null
+  query.offset + query.limit <= results.hits.total
+    ? query.offset + query.limit
+    : null
 );
 
 const transformSearchResults = query => results => ({

--- a/src/routes/vessels.js
+++ b/src/routes/vessels.js
@@ -1,14 +1,20 @@
 const datasets = require('../data/datasets');
 const vessels = require('../data/vessels');
 const tracks = require('../data/tracks');
+const log = require('../data/log');
 
 const loadDataset = async (req, res, next) => {
   try {
     const datasetId = req.swagger.params.dataset.value;
+
+    log.debug(`Looking up dataset ${datasetId}`)
     const dataset = await datasets.get(datasetId);
     if (!dataset) {
+      log.debug("Dataset not found");
       return res.sendStatus(404);
     }
+
+    log.debug("Dataset found", dataset);
     req.dataset = dataset;
     return next();
   } catch (err) {
@@ -25,8 +31,10 @@ module.exports = (app) => {
         offset: req.swagger.params.offset.value,
       };
 
+      log.debug("Querying vessels search index");
       const results = await vessels(req.dataset).search(query);
 
+      log.debug(`Returning ${results.entries.length} / ${results.total} results`)
       return res.json(results);
     } catch(error) {
       return next(error);
@@ -37,8 +45,10 @@ module.exports = (app) => {
     try {
       const vesselId = req.swagger.params.vesselId.value;
 
+      log.debug(`Looking up vessel information for vessel ${vesselid}`);
       const result = await vessels(req.dataset).get(vesselId);
 
+      log.debug("Returning vessel information");
       return res.json(result);
     } catch(error) {
       return next(error);
@@ -50,8 +60,10 @@ module.exports = (app) => {
     try {
       const vesselId = req.swagger.params.vesselId.value;
 
-      const result = await tracks(req.dataset).forVessel(vesselId);
+      log.debug(`Looking up track for vessel ${vesselId}`);
+      const result = await tracks(req.dataset).forVessel(vesselId, req.swagger.params.features.value);
 
+      log.debug(`Returning track for vessel ${vesselId}`);
       return res.json(result);
     } catch(error) {
       return next(error);

--- a/src/routes/vessels.js
+++ b/src/routes/vessels.js
@@ -7,14 +7,14 @@ const loadDataset = async (req, res, next) => {
   try {
     const datasetId = req.swagger.params.dataset.value;
 
-    log.debug(`Looking up dataset ${datasetId}`)
+    log.debug(`Looking up dataset ${datasetId}`);
     const dataset = await datasets.get(datasetId);
     if (!dataset) {
-      log.debug("Dataset not found");
+      log.debug('Dataset not found');
       return res.sendStatus(404);
     }
 
-    log.debug("Dataset found", dataset);
+    log.debug('Dataset found', dataset);
     req.dataset = dataset;
     return next();
   } catch (err) {
@@ -31,12 +31,13 @@ module.exports = (app) => {
         offset: req.swagger.params.offset.value,
       };
 
-      log.debug("Querying vessels search index");
-      const results = await vessels(req.dataset).search(query);
+      log.debug('Querying vessels search index');
+      const results = await vessels(req.dataset)
+        .search(query);
 
-      log.debug(`Returning ${results.entries.length} / ${results.total} results`)
+      log.debug(`Returning ${results.entries.length} / ${results.total} results`);
       return res.json(results);
-    } catch(error) {
+    } catch (error) {
       return next(error);
     }
   });
@@ -45,12 +46,13 @@ module.exports = (app) => {
     try {
       const vesselId = req.swagger.params.vesselId.value;
 
-      log.debug(`Looking up vessel information for vessel ${vesselid}`);
-      const result = await vessels(req.dataset).get(vesselId);
+      log.debug(`Looking up vessel information for vessel ${vesselId}`);
+      const result = await vessels(req.dataset)
+        .get(vesselId);
 
-      log.debug("Returning vessel information");
+      log.debug('Returning vessel information');
       return res.json(result);
-    } catch(error) {
+    } catch (error) {
       return next(error);
     }
   });
@@ -61,11 +63,12 @@ module.exports = (app) => {
       const vesselId = req.swagger.params.vesselId.value;
 
       log.debug(`Looking up track for vessel ${vesselId}`);
-      const result = await tracks(req.dataset).forVessel(vesselId, req.swagger.params.features.value);
+      const result = await tracks(req.dataset)
+        .forVessel(vesselId, req.swagger.params.features.value);
 
       log.debug(`Returning track for vessel ${vesselId}`);
       return res.json(result);
-    } catch(error) {
+    } catch (error) {
       return next(error);
     }
   });

--- a/src/services/elasticsearch.js
+++ b/src/services/elasticsearch.js
@@ -1,6 +1,6 @@
-const config = require('../config');
 const { Client } = require('elasticsearch');
+const config = require('../config');
 
 module.exports = new Client({
   host: config.elasticsearch.server,
-})
+});


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/965
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/961

These changes add a new parameter to the tracks API, `features`, which allows the client to request additional features besides simple tracks in the resulting GeoJSON. For now, the following values are supported:

* `fishing`: Adds additional features to the root `FeatureCollection` containing the points at which fishing was detected in the tracks.
* `speed` and `course`: Adds additional properties to the `coordinateProperties` of each track which include per-point speed and course respectively.

By default, if the parameter is empty no extra information besides the track will be returned.

This is an example of how the track is returned for some example vessels in the indonesian dataset:

https://gist.github.com/andres-arana/6280b15345c693a773e49e2f9b588cd1
