### PR TITLE
1054 Revert format changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   cloudsql:
     image: gcr.io/cloudsql-docker/gce-proxy:1.12 
-    command: "/cloud_sql_proxy -instances=world-fishing-827:us-central1-a:api -dir=/cloudsql"
+    command: "/cloud_sql_proxy -instances=world-fishing-827:us-central1:api -dir=/cloudsql"
     volumes:
       - "~/.config/gcloud:/root/.config/gcloud"
       - "cloudsql-sockets:/cloudsql"

--- a/spec/data/tracks.spec.js
+++ b/spec/data/tracks.spec.js
@@ -31,14 +31,19 @@ describe("data/tracks", () => {
         );
 
         expect(result).to.deep.equal({
-          type: "Feature",
-          geometry: {
-            type: "LineString",
-            coordinates: [[100, 60], [100, 61], [101, 60]]
-          },
-          coordinateProperties: {
-            times: [1546300800000, 1546304400000, 1546300800000]
-          }
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              geometry: {
+                type: "LineString",
+                coordinates: [[100, 60], [100, 61], [101, 60]]
+              },
+              coordinateProperties: {
+                times: [1546300800000, 1546304400000, 1546300800000]
+              }
+            }
+          ]
         });
       });
 
@@ -78,17 +83,22 @@ describe("data/tracks", () => {
         }).formatters.lines(records);
 
         expect(result).to.deep.equal({
-          type: "Feature",
-          geometry: {
-            type: "LineString",
-            coordinates: [[100, 60], [100, 61], [101, 60]]
-          },
-          coordinateProperties: {
-            times: [1546300800000, 1546304400000, 1546300800000],
-            scores: [1, 2, 3],
-            courses: [10, 20, 30],
-            speeds: [100, 200, 300]
-          }
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              geometry: {
+                type: "LineString",
+                coordinates: [[100, 60], [100, 61], [101, 60]]
+              },
+              coordinateProperties: {
+                times: [1546300800000, 1546304400000, 1546300800000],
+                fishing: [1, 2, 3],
+                courses: [10, 20, 30],
+                speeds: [100, 200, 300]
+              }
+            }
+          ]
         });
       });
     });
@@ -185,7 +195,7 @@ describe("data/tracks", () => {
               geometry: { type: "Point", coordinates: [100, 60] },
               properties: {
                 timestamp: 1546300800000,
-                score: 1,
+                fishing: 1,
                 course: 10,
                 speed: 100
               }
@@ -195,7 +205,7 @@ describe("data/tracks", () => {
               geometry: { type: "Point", coordinates: [100, 61] },
               properties: {
                 timestamp: 1546304400000,
-                score: 2,
+                fishing: 2,
                 course: 20,
                 speed: 200
               }
@@ -205,7 +215,7 @@ describe("data/tracks", () => {
               geometry: { type: "Point", coordinates: [101, 60] },
               properties: {
                 timestamp: 1546300800000,
-                score: 3,
+                fishing: 3,
                 course: 30,
                 speed: 300
               }

--- a/src/data/tracks.js
+++ b/src/data/tracks.js
@@ -8,8 +8,8 @@ const featureSettings = {
     formatter: value => new Date(value).getTime()
   },
   fishing: {
-    coordinateProperty: "scores",
-    property: "score",
+    coordinateProperty: "fishing",
+    property: "fishing",
     databaseField: "score",
     formatter: value => value
   },
@@ -63,13 +63,18 @@ module.exports = ({ dataset, additionalFeatures = [] }) => {
           };
         }, {});
 
-        return {
+        const geoJSONFeature = {
           type: "Feature",
           geometry: {
             type: "LineString",
             coordinates
           },
           coordinateProperties
+        };
+
+        return {
+          type: "FeatureCollection",
+          features: [geoJSONFeature]
         };
       },
 


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1054

We are back to having a `FeatureCollection` as the root document of the geojson tracks. Also, the `score` property is `fishing` again.