### PR TITLE
Filter tracks by timerange

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "extends": [
+    "airbnb-base",
+    "plugin:prettier/recommended"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dev/
 *~
 tags
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ CMD ["npm", "start"]
 ENV NODE_ENV=production
 
 # Setup application dependencies
-copy package*.json /opt/project/
+COPY package*.json /opt/project/
 RUN npm --unsafe-perm install --only production
 
 # Setup the application code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - NODE_ENV=development
 
   cloudsql:
-    image: gcr.io/cloudsql-docker/gce-proxy:1.12 
+    image: gcr.io/cloudsql-docker/gce-proxy:1.12
     command: "/cloud_sql_proxy -instances=world-fishing-827:us-central1:api -dir=/cloudsql"
     volumes:
       - "~/.config/gcloud:/root/.config/gcloud"
@@ -30,7 +30,7 @@ services:
   swagger:
     image: swaggerapi/swagger-ui
     ports:
-      - "3000:8080"
+      - "${PORT-3000}:8080"
     environment:
       - URL=http://localhost:8080/openapi.json
 

--- a/package.json
+++ b/package.json
@@ -51,15 +51,5 @@
     "eslint-plugin-prettier": "^3.0.1",
     "mocha": "^6.0.0",
     "prettier": "^1.17.0"
-  },
-  "eslintConfig": {
-    "env": {
-      "node": true,
-      "mocha": true
-    },
-    "extends": [
-      "airbnb-base",
-      "plugin:prettier/recommended"
-    ]
   }
 }

--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -107,10 +107,21 @@ definitions:
           - track
       coordinateProperties:
         description: |
-          list of timestamps of each segment position
+          list of features requested in the track of each segment position,
+          by default only includes times but also available courses and speeds
         type: object
+        required:
+          - times
         properties:
           times:
+            type: array
+            items:
+              type: number
+          courses:
+            type: array
+            items:
+              type: number
+          speed:
             type: array
             items:
               type: number

--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -249,6 +249,20 @@ paths:
               - fishing
               - speed
               - course
+        - name: startDate
+          in: query
+          description: |
+            Temporary filter for the track, will return only the paths of the track
+            which happened after this moment
+          type: string
+          format: date-time
+        - name: endDate
+          in: query
+          description: |
+            Temporary filter for the track, will return only the paths of the track
+            which happened before this moment
+          type: string
+          format: date-time
         - name: format
           in: query
           description: |

--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -47,6 +47,91 @@ definitions:
             description:
               type: string
 
+  GeometryCollection:
+    type: object
+    description: Geojson geometry collection
+    required:
+      - type
+      - geometry
+    externalDocs:
+      url: http://geojson.org/geojson-spec.html#geometrycollection
+    discriminator: type
+    properties:
+      type:
+        type: string
+        description: the geometry type
+        enum:
+          - Point
+          - LineString
+          - Polygon
+          - MultiPoint
+          - MultiLineString
+          - MultiPolygon
+      geometry:
+        type: object
+
+  Feature:
+    type: object
+    description: Geojson Feature
+    required:
+      - type
+      - geometry
+      - properties
+    externalDocs:
+      url: https://tools.ietf.org/html/rfc7946#section-3.2
+    properties:
+      type:
+        type: string
+        enum:
+          - Feature
+      id:
+        type: string
+      geometry:
+        $ref: '#/definitions/GeometryCollection'
+      properties:
+        $ref: '#/definitions/FeatureProperties'
+
+  FeatureProperties:
+    type: object
+    properties:
+      segId:
+        description: |
+          unique identifier of the event segment
+        type: string
+      type:
+        description: |
+          type of the event that the feature represents
+        type: string
+        enum:
+          - fishing
+          - track
+      coordinateProperties:
+        description: |
+          list of timestamps of each segment position
+        type: object
+        properties:
+          times:
+            type: array
+            items:
+              type: number
+
+  GeojsonTrack:
+    type: object
+    description: Geojson Feature collection
+    required:
+      - type
+      - features
+    externalDocs:
+      url: https://tools.ietf.org/html/rfc7946#section-3.3
+    properties:
+      type:
+        type: string
+        enum:
+          - FeatureCollection
+      features:
+        type: array
+        items:
+          $ref: '#/definitions/Feature'
 responses:
   BadRequest:
     description: |
@@ -280,6 +365,8 @@ paths:
         '200':
           description: |
             Expected resposne to a successful request.
+          schema:
+            $ref: '#/definitions/GeojsonTrack'
         '401':
           $ref: '#/responses/Unauthorized'
         '400':

--- a/src/routes/vessels.js
+++ b/src/routes/vessels.js
@@ -109,6 +109,10 @@ module.exports = app => {
     async (req, res, next) => {
       try {
         const vesselId = req.swagger.params.vesselId.value;
+        const params = {
+          startDate: req.swagger.params.startDate.value,
+          endDate: req.swagger.params.endDate.value
+        };
         const format = req.swagger.params.format.value;
         const features = req.swagger.params.features.value;
 
@@ -119,7 +123,8 @@ module.exports = app => {
         );
         const trackLoader = tracks({
           dataset: req.dataset,
-          additionalFeatures: features
+          additionalFeatures: features,
+          params
         });
 
         log.debug(`Looking up track for vessel ${vesselId}`);


### PR DESCRIPTION
Adds `startDate` and `endDate` filters, in iso-string format, for vessel track API. 

Really useful in places like carrier portal where we only need data from 2007, as it saves almost half a mg of data transfer and is quicker to respond.

All track
![image](https://user-images.githubusercontent.com/10500650/62682668-0546e300-b9bd-11e9-82a0-82a7eef49e7d.png)

2017 Track
![image](https://user-images.githubusercontent.com/10500650/62682684-0aa42d80-b9bd-11e9-8da0-e796b716581c.png)

Also adds the response format for the geojson schema