### PR TITLE
fix eslint deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY package*.json /opt/project/
 RUN npm --unsafe-perm install --only production
 
 # Setup the application code
+COPY .eslintrc.json /opt/project/
 COPY src /opt/project/src
 
 ################################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "./src:/opt/project/src"
       - "./spec:/opt/project/spec"
       - "./package.json:/opt/project/package.json"
+      - "./.eslintrc.json:/opt/project/.eslintrc.json"
       - "./dev:/opt/project/dev"
       - "cloudsql-sockets:/cloudsql"
       - "~/.config/gcloud:/root/.config/gcloud"

--- a/package.json
+++ b/package.json
@@ -51,15 +51,5 @@
     "eslint-plugin-prettier": "^3.0.1",
     "mocha": "^6.0.0",
     "prettier": "^1.17.0"
-  },
-  "eslintConfig": {
-    "env": {
-      "node": true,
-      "mocha": true
-    },
-    "extends": [
-      "airbnb-base",
-      "plugin:prettier/recommended"
-    ]
   }
 }


### PR DESCRIPTION
We don't have the eslintConfig on the package.json anymore so we have to copy the .eslintrc file by hand into the project folder to avoid missing eslint config in the deploy.