### PR TITLE
add queryFields param to match query filters

### DIFF
--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -143,6 +143,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Feature'
+
 responses:
   BadRequest:
     description: |
@@ -182,6 +183,13 @@ paths:
             Search query.
           required: true
           type: string
+        - name: queryFields
+          in: query
+          description: |
+            List of fields to match with the search query instead of the entire object property
+          type: array
+          items:
+            type: string
         - name: limit
           in: query
           description: |
@@ -257,6 +265,13 @@ paths:
             Search query.
           required: true
           type: string
+        - name: queryFields
+          in: query
+          description: |
+            List of fields to match with the search query instead of the entire object property
+          type: array
+          items:
+            type: string
         - name: limit
           in: query
           description: |

--- a/src/data/vessels.js
+++ b/src/data/vessels.js
@@ -45,7 +45,8 @@ module.exports = source => {
           query: {
             query_string: {
               query: `*${query.query}*`,
-              allow_leading_wildcard: true
+              allow_leading_wildcard: true,
+              ...(query.queryFields && { fields: query.queryFields })
             }
           }
         }

--- a/src/routes/vessels.js
+++ b/src/routes/vessels.js
@@ -26,7 +26,8 @@ module.exports = app => {
       const query = {
         query: req.swagger.params.query.value,
         limit: req.swagger.params.limit.value,
-        offset: req.swagger.params.offset.value
+        offset: req.swagger.params.offset.value,
+        queryFields: req.swagger.params.queryFields.value
       };
 
       log.debug("Querying vessels search index");
@@ -67,7 +68,8 @@ module.exports = app => {
       const query = {
         query: req.swagger.params.query.value,
         limit: req.swagger.params.limit.value,
-        offset: req.swagger.params.offset.value
+        offset: req.swagger.params.offset.value,
+        queryFields: req.swagger.params.queryFields.value
       };
 
       log.debug("Querying vessels search index");


### PR DESCRIPTION
This PR adds a new query param to be able to filter results which only matches certain fields in the entity called `queryFields` using elastic search [multi-match-query ](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html)

For example, when we want to search vessels with the name `LYTR` we will get one result as the callsign properties matches:

![image](https://user-images.githubusercontent.com/10500650/63165849-dcfa5c80-c02c-11e9-9c3a-0ee369177727.png)

but as we only want results with that name we can include now `queryFields: name` to obtain a more accurate search result:

![image](https://user-images.githubusercontent.com/10500650/63165829-d23fc780-c02c-11e9-8f76-7475b935bd44.png)


