### PR TITLE
Fix antimeridian tracks render

### DIFF
--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -390,8 +390,10 @@ paths:
         - name: wrapLongitudes
           in: query
           description: |
-            Specific longitued response to use longitudes above and below 180 and -180 and avoid antimeridian
-            rendering issues (https://macwright.org/2016/09/26/the-180th-meridian.html)
+            When false, deviate from the geojson standard and don't wrap longitudes between [-180, 180],
+            so that tracks going over the antimeridean line don't reset back to the negated longitudes.
+            This should be false if you are using an atlantic-centered visualization, such as QGis, or when
+            using leaflet or mapbox to render the track. See https://macwright.org/2016/09/26/the-180th-meridian.html.
           type: boolean
           default: true
       responses:

--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -387,6 +387,13 @@ paths:
             - lines
             - points
           default: lines
+        - name: wrapLongitudes
+          in: query
+          description: |
+            Specific longitued response to use longitudes above and below 180 and -180 and avoid antimeridian
+            rendering issues (https://macwright.org/2016/09/26/the-180th-meridian.html)
+          type: boolean
+          default: true
       responses:
         '200':
           description: |

--- a/src/api/index.yaml
+++ b/src/api/index.yaml
@@ -395,7 +395,7 @@ paths:
             This should be false if you are using an atlantic-centered visualization, such as QGis, or when
             using leaflet or mapbox to render the track. See https://macwright.org/2016/09/26/the-180th-meridian.html.
           type: boolean
-          default: true
+          default: false
       responses:
         '200':
           description: |

--- a/src/routes/vessels.js
+++ b/src/routes/vessels.js
@@ -113,7 +113,8 @@ module.exports = app => {
         const vesselId = req.swagger.params.vesselId.value;
         const params = {
           startDate: req.swagger.params.startDate.value,
-          endDate: req.swagger.params.endDate.value
+          endDate: req.swagger.params.endDate.value,
+          wrapLongitudes: req.swagger.params.wrapLongitudes.value
         };
         const format = req.swagger.params.format.value;
         const features = req.swagger.params.features.value;


### PR DESCRIPTION
To avoid rendering issues with the antimeridian after reading: https://macwright.org/2016/09/26/the-180th-meridian.html this PR includes a quick hack to use longitudes above and below 180 and -180 (support checked only in mapbox, leaflet and qgis)

